### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -19,18 +19,18 @@ jobs:
     steps:
 
       - name: Checkout-Main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.base_ref }}
           path: ${{ github.base_ref }}
 
       - name: Checkout-HEAD
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           path: ${{ github.head_ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
 

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         env:
           cache-name: cache-go-modules
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
@@ -38,15 +38,15 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
@@ -62,15 +62,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
@@ -87,15 +87,15 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
@@ -142,22 +142,22 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Cache Build
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: ~/.cache/go-build
           key: unittest-${{ runner.os }}-go-build-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
@@ -185,29 +185,29 @@ jobs:
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.6
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Cache Build
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: ~/.cache/go-build
           key: coverage-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests With Coverage
         run: make gotest-with-cover
       - name: Upload coverage report
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
         with:
           action: codecov/codecov-action@v3
           with: |
@@ -253,15 +253,15 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
       - name: Test

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5
         with:
           distribution: goreleaser-pro
           version: latest
@@ -31,7 +31,7 @@ jobs:
           gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} -n "### Images and binaries here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const milestones = await github.rest.issues.listMilestones({

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,16 +23,16 @@ jobs:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -18,7 +18,7 @@ jobs:
       md: ${{ steps.changes.outputs.md }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Get changed files
@@ -31,7 +31,7 @@ jobs:
     if: ${{needs.changedfiles.outputs.md}}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
 

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -14,7 +14,7 @@ jobs:
       already-added: ${{ steps.check-versions.outputs.already-added }}
       already-opened: ${{ steps.check-versions.outputs.already-opened }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - id: check-versions
         name: Check versions
@@ -54,9 +54,9 @@ jobs:
     needs:
       - check-versions
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Checkout semantic-convention
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: open-telemetry/semantic-convention
           path: tmp-semantic-conventions

--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const milestones = await github.rest.issues.listMilestones({

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,10 +8,10 @@ jobs:
   runperf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
@@ -51,7 +51,7 @@ jobs:
           REPO: open-telemetry/opentelemetry-collector-contrib
         run: ./.github/workflows/scripts/release-check-build-status.sh
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
       # Prepare Core for release.

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 14 days.'

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'renovatebot') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: ~1.20.12
           cache: false
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             ~/go/bin
@@ -39,6 +39,6 @@ jobs:
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
           echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy\" && git push)"
           git diff --exit-code || (git add . && git commit -m "go mod tidy" && git push)
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
         with:
           labels: renovatebot


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/cache@v3 -> @6f8efc29...`
- `Wandalen/wretry.action@v1.3.0 -> @a163f62a...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `goreleaser/goreleaser-action@v5 -> @5742e2a0...`
- `actions/github-script@v7 -> @f28e40c7...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/github-script@v7 -> @f28e40c7...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/checkout@v4 -> @34e11487...`
- `ludeeus/action-shellcheck@2.0.0 -> @00cae500...`
- `actions/stale@v9 -> @5bef64f1...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `actions/cache@v3 -> @6f8efc29...`
- `actions-ecosystem/action-remove-labels@v1 -> @2ce5d41b...`


### Why

This repo was flagged as **HIGH** risk: unpinned actions triggered by pull requests allow fork-based supply chain attacks.

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
